### PR TITLE
Remove unused SW instruction support

### DIFF
--- a/src/henad.v
+++ b/src/henad.v
@@ -51,8 +51,8 @@ module henad(
     wire [11:0] final_instr;
 
 
-    reg  [3:0] ifid_set_reg;
-    wire [3:0] ifid_set;
+    // Current instruction set (constant as SW is unused)
+    wire [3:0] ifid_set = `ISET_R;
     // Instruction set value at each pipeline stage
     wire [3:0] idex_set;
     wire [3:0] exma_set;
@@ -245,22 +245,7 @@ module henad(
     );
 
 
-    // Instruction set tracking register.  The decode stage outputs the set
-    // for the current instruction and this register feeds the next
-    // instruction into the pipeline so that SW instructions take effect.
-    assign ifid_set = ifid_set_reg;
-
-    // Determine the instruction set for the next instruction.  A switch (SW)
-    // instruction selects a new set; otherwise the current set is preserved.
-    wire [3:0] next_ifid_set =
-        (ifid_instr[11:8] == `OPC_SW) ? {1'b0, ifid_instr[2:0]} : ifid_set_reg;
-
-    always @(posedge clk or posedge rst) begin
-        if (rst)
-            ifid_set_reg <= `ISET_R;
-        else if (stage2id_en)
-            ifid_set_reg <= next_ifid_set;
-    end
+    // Instruction set is fixed; no dynamic switching required.
 
     // ID stage
     stage2id u_stage2id(

--- a/src/opcodes.vh
+++ b/src/opcodes.vh
@@ -5,7 +5,6 @@
 
 // OPCODES independent of instruction set
 `define OPC_NOP      4'h0
-`define OPC_SW       4'h1
 
 // REGISTER SET
 `define OPC_R_MOV    4'h2

--- a/src/stage2id.v
+++ b/src/stage2id.v
@@ -33,14 +33,13 @@ module stage2id(
     // Propagate enable to the next stage
     assign enable_out = enable_in;
 
-    // Decode stage: update instruction set when a SW instruction is seen
+    // Decode stage: use the current instruction set directly
     wire [3:0] opcode = instr_in[11:8];
-    wire [3:0] stage_set = (opcode == `OPC_SW) ? {1'b0, instr_in[2:0]}
-                                              : instr_set_in;
+    wire [3:0] stage_set = instr_set_in;
 
     // Replace handled instructions with NOPs
     wire [11:0] forwarded_instr =
-        (opcode == `OPC_NOP || opcode == `OPC_SW) ? 12'b0 : instr_in;
+        (opcode == `OPC_NOP) ? 12'b0 : instr_in;
 
     // Decode immediate, register and branch fields
     wire [3:0] bcc_w       = forwarded_instr[7:4];


### PR DESCRIPTION
## Summary
- delete `OPC_SW` opcode
- simplify decode stage to ignore SW
- make instruction set fixed in top-level core

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp > simulation.log`

------
https://chatgpt.com/codex/tasks/task_e_685e49507e88832f90e4b8ef1cdb02b8