### PR TITLE
Fix pipeline instruction width

### DIFF
--- a/src/stage2id.v
+++ b/src/stage2id.v
@@ -20,7 +20,8 @@ module stage2id(
     output wire [3:0]  src_gp_out,
     output wire [3:0]  src_sr_out,
     output wire        imm_en_out,
-    output wire [23:0] imm_val_out,
+    // Lower 12 bits hold the immediate value extracted from the instruction
+    output wire [11:0] imm_val_out,
     output wire        sgn_en_out,
     // Stall signal from the hazard unit. When asserted, a NOP is
     // inserted instead of the decoded instruction.

--- a/src/stage3ex.v
+++ b/src/stage3ex.v
@@ -44,7 +44,8 @@ module stage3ex(
     // Propagate the enable signal to the next stage.  For the special
     // halt instruction the pipeline is stalled by clearing the enable
     // line.
-    assign enable_out = (instr_in[11:8] == `OPC_S_HLT) ? 1'b0 : enable_in;
+    // Halt instructions reside in the upper opcode byte
+    assign enable_out = (instr_in[23:16] == `OPC_S_HLT) ? 1'b0 : enable_in;
 
     // Stage output prior to latching.  This is kept as a separate wire so
     // that future execute logic can easily be inserted here.

--- a/src/stage4ma.v
+++ b/src/stage4ma.v
@@ -6,18 +6,19 @@ module stage4ma(
     input  wire        rst,
     input  wire        enable_in,
     output wire        enable_out,
-    input  wire [11:0] pc_in,
-    input  wire [11:0] instr_in,
-    input  wire [11:0] result_in,
-    input  wire [11:0] store_data_in,
+    // Full 24-bit wide pipeline signals
+    input  wire [23:0] pc_in,
+    input  wire [23:0] instr_in,
+    input  wire [23:0] result_in,
+    input  wire [23:0] store_data_in,
     input  wire [3:0]  flags_in,
-    output wire [11:0] pc_out,
-    output wire [11:0] instr_out,
-    output wire [11:0] result_out,
+    output wire [23:0] pc_out,
+    output wire [23:0] instr_out,
+    output wire [23:0] result_out,
     output wire [3:0]  flags_out,
-    output wire [11:0] store_data_out,
+    output wire [23:0] store_data_out,
     // Address line for the data memory
-    output wire [11:0] mem_addr
+    output wire [23:0] mem_addr
 );
     // Propagate the enable signal to the next stage.  Any PC update is
     // determined below based on the instruction type.
@@ -27,15 +28,16 @@ module stage4ma(
     // program counter from the execute stage (result_in) contains the next
     // address. Otherwise the original PC is forwarded.  Keeping this in a
     // separate wire allows for future memory address calculations.
-    wire [3:0] opcode = instr_in[11:8];
+    // Decode opcode from the upper byte of the instruction
+    wire [7:0] opcode = instr_in[23:16];
     wire branch_instr = (opcode == `OPC_R_BCC)  ||
                         (opcode == `OPC_I_BCCi) ||
                         (opcode == `OPC_IS_BCCis) ||
                         (opcode == `OPC_S_SRBCC);
-    wire [11:0] stage_pc = branch_instr ? result_in : pc_in;
-    wire [11:0] stage_result = result_in;
+    wire [23:0] stage_pc = branch_instr ? result_in : pc_in;
+    wire [23:0] stage_result = result_in;
     wire [3:0]  stage_flags  = flags_in;
-    wire [11:0] stage_store_data = store_data_in;
+    wire [23:0] stage_store_data = store_data_in;
 
     // Determine if this is a memory access instruction and set the
     // data memory address accordingly.  The execute stage provides the
@@ -44,22 +46,22 @@ module stage4ma(
                      (opcode == `OPC_I_LDi) ||
                      (opcode == `OPC_R_ST) ||
                      (opcode == `OPC_I_STi);
-    assign mem_addr = mem_instr ? result_in : 12'b0;
+    assign mem_addr = mem_instr ? result_in : 24'b0;
 
     // Latch registers between MA and MO stages
-    reg [11:0] pc_latch;
-    reg [11:0] instr_latch;
-    reg [11:0] result_latch;
+    reg [23:0] pc_latch;
+    reg [23:0] instr_latch;
+    reg [23:0] result_latch;
     reg [3:0]  flags_latch;
-    reg [11:0] store_data_latch;
+    reg [23:0] store_data_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            pc_latch    <= 12'b0;
-            instr_latch <= 12'b0;
-            result_latch<= 12'b0;
+            pc_latch    <= 24'b0;
+            instr_latch <= 24'b0;
+            result_latch<= 24'b0;
             flags_latch <= 4'b0;
-            store_data_latch <= 12'b0;
+            store_data_latch <= 24'b0;
         end else if (enable_in) begin
             pc_latch    <= stage_pc;
             instr_latch <= instr_in;

--- a/src/stage4mo.v
+++ b/src/stage4mo.v
@@ -6,26 +6,27 @@ module stage4mo(
     input  wire        rst,
     input  wire        enable_in,
     output wire        enable_out,
-    input  wire [11:0] pc_in,
-    input  wire [11:0] instr_in,
-    input  wire [11:0] result_in,
-    input  wire [11:0] store_data_in,
+    input  wire [23:0] pc_in,
+    input  wire [23:0] instr_in,
+    input  wire [23:0] result_in,
+    input  wire [23:0] store_data_in,
     input  wire [3:0]  flags_in,
     // Data returned from the data memory
-    input  wire [11:0] mem_rdata,
-    output wire [11:0] pc_out,
-    output wire [11:0] instr_out,
-    output wire [11:0] result_out,
+    input  wire [23:0] mem_rdata,
+    output wire [23:0] pc_out,
+    output wire [23:0] instr_out,
+    output wire [23:0] result_out,
     output wire [3:0]  flags_out,
     // Write interface for the data memory
-    output wire [11:0] mem_wdata,
+    output wire [23:0] mem_wdata,
     output wire        mem_we
 );
     // Propagate enable directly to the next stage
     assign enable_out = enable_in;
 
     // Decode opcode for load/store behaviour
-    wire [3:0] opcode = instr_in[11:8];
+    // Decode opcode from the full instruction
+    wire [7:0] opcode = instr_in[23:16];
     wire       load_instr  = (opcode == `OPC_R_LD)  ||
                              (opcode == `OPC_I_LDi);
     wire       store_instr = (opcode == `OPC_R_ST)  ||
@@ -33,24 +34,24 @@ module stage4mo(
 
     // For load instructions use the memory data as the result.  All
     // other instructions simply forward the execute stage result.
-    wire [11:0] stage_pc     = pc_in;
-    wire [11:0] stage_result = load_instr ? mem_rdata : result_in;
+    wire [23:0] stage_pc     = pc_in;
+    wire [23:0] stage_result = load_instr ? mem_rdata : result_in;
     wire [3:0]  stage_flags  = flags_in;
 
     assign mem_wdata = store_data_in;
     assign mem_we    = enable_in && store_instr;
 
     // Latch registers between the MO stage and the Register Address stage
-    reg [11:0] pc_latch;
-    reg [11:0] instr_latch;
-    reg [11:0] result_latch;
+    reg [23:0] pc_latch;
+    reg [23:0] instr_latch;
+    reg [23:0] result_latch;
     reg [3:0]  flags_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            pc_latch    <= 12'b0;
-            instr_latch <= 12'b0;
-            result_latch<= 12'b0;
+            pc_latch    <= 24'b0;
+            instr_latch <= 24'b0;
+            result_latch<= 24'b0;
             flags_latch <= 4'b0;
         end else if (enable_in) begin
             pc_latch    <= stage_pc;

--- a/src/stage5ra.v
+++ b/src/stage5ra.v
@@ -5,13 +5,13 @@ module stage5ra(
     input  wire        rst,
     input  wire        enable_in,
     output wire        enable_out,
-    input  wire [11:0] pc_in,
-    input  wire [11:0] instr_in,
-    input  wire [11:0] result_in,
+    input  wire [23:0] pc_in,
+    input  wire [23:0] instr_in,
+    input  wire [23:0] result_in,
     input  wire [3:0]  flags_in,
-    output wire [11:0] pc_out,
-    output wire [11:0] instr_out,
-    output wire [11:0] result_out,
+    output wire [23:0] pc_out,
+    output wire [23:0] instr_out,
+    output wire [23:0] result_out,
     output wire [3:0]  flags_out,
     // Decoded register address for the writeback stage
     output wire [3:0]  reg_waddr_out
@@ -21,24 +21,24 @@ module stage5ra(
 
     // The Register Address stage currently performs no logic and simply
     // forwards the program counter.
-    wire [11:0] stage_pc     = pc_in;
-    wire [11:0] stage_result = result_in;
+    wire [23:0] stage_pc     = pc_in;
+    wire [23:0] stage_result = result_in;
     wire [3:0]  stage_flags  = flags_in;
     // Target register address extracted from the instruction
     wire [3:0]  stage_waddr  = instr_in[7:4];
 
     // Latch registers between RA and RO stages
-    reg [11:0] pc_latch;
-    reg [11:0] instr_latch;
-    reg [11:0] result_latch;
+    reg [23:0] pc_latch;
+    reg [23:0] instr_latch;
+    reg [23:0] result_latch;
     reg [3:0]  flags_latch;
     reg [3:0]  waddr_latch;
 
     always @(posedge clk or posedge rst) begin
         if (rst) begin
-            pc_latch    <= 12'b0;
-            instr_latch <= 12'b0;
-            result_latch<= 12'b0;
+            pc_latch    <= 24'b0;
+            instr_latch <= 24'b0;
+            result_latch<= 24'b0;
             flags_latch <= 4'b0;
             waddr_latch <= 4'b0;
         end else if (enable_in) begin

--- a/src/stage5ro.v
+++ b/src/stage5ro.v
@@ -6,19 +6,19 @@ module stage5ro(
     input  wire        clk,
     input  wire        rst,
     input  wire        enable_in,
-    input  wire [11:0] pc_in,
-    input  wire [11:0] instr_in,
-    input  wire [11:0] result_in,
+    input  wire [23:0] pc_in,
+    input  wire [23:0] instr_in,
+    input  wire [23:0] result_in,
     input  wire [3:0]  flags_in,
     // Register address prepared by the RA stage
     input  wire [3:0]  reg_waddr_in,
-    output wire [11:0] pc_out,
-    output wire [11:0] instr_out,
+    output wire [23:0] pc_out,
+    output wire [23:0] instr_out,
     output wire [3:0]  reg_waddr,
-    output wire [11:0] reg_wdata,
+    output wire [23:0] reg_wdata,
     output wire        reg_we,
     // Write interface for the link register
-    output wire [11:0] lr_wdata,
+    output wire [23:0] lr_wdata,
     output wire        lr_we,
     output wire [3:0]  flag_wdata,
     output wire        flag_we
@@ -28,7 +28,8 @@ module stage5ro(
     `include "src/iset.vh"
     `undef DEFINE_REG_WRITE_FN
     // Decode opcode for write-back decisions
-    wire [3:0] opcode = instr_in[11:8];
+    // Use the upper byte of the instruction for opcode decoding
+    wire [7:0] opcode = instr_in[23:16];
 
     wire reg_write = reg_write_fn(opcode);
 


### PR DESCRIPTION
## Summary
- widen stage4/5 pipeline modules to handle full 24-bit instructions
- decode the halt instruction from the upper opcode byte
- make stage2id immediate output 12 bits

## Testing
- `iverilog -g2012 -DDEBUGPC -DDEBUGINSTR -DDEBUGRES -DDEBUGIR -DDEBUGLR -DDEBUGREG -o test_debug.vvp src/*.v`
- `vvp test_debug.vvp > sim.log` *(fails: registers remain zero)*


------
https://chatgpt.com/codex/tasks/task_e_68619332e7d0832f8f3601c66718244a