### PR TITLE
Add halt instruction logic

### DIFF
--- a/src/diad.v
+++ b/src/diad.v
@@ -94,7 +94,7 @@ module diad(
     always @(posedge clk or posedge rst) begin
         if (rst) begin
             halted <= 1'b0;
-        end else if ((idex_instr[23:16] == `OPC_S_HLT) && stage3ex_en) begin
+        end else if (ex_halt) begin
             halted <= 1'b1;
         end
     end
@@ -122,6 +122,7 @@ module diad(
     wire [23:0] ex_store_data;
     wire [3:0]  ex_flags;
     wire        ex_branch_taken;
+    wire        ex_halt;
     wire [23:0] ma_result;
     wire [23:0] ma_store_data;
     wire [3:0]  ma_flags;
@@ -306,7 +307,8 @@ module diad(
         .result_out(ex_result),
         .flags_out(ex_flags),
         .store_data_out(ex_store_data),
-        .branch_taken_out(ex_branch_taken)
+        .branch_taken_out(ex_branch_taken),
+        .halt_out(ex_halt)
     );
 
     // Memory address stage

--- a/src/stage3ex.v
+++ b/src/stage3ex.v
@@ -39,13 +39,16 @@ module stage3ex(
     // Data value for store instructions
     output wire [23:0] store_data_out,
     // Asserted when a branch condition is met
-    output wire        branch_taken_out
+    output wire        branch_taken_out,
+    // Asserted for a single cycle when a HLT instruction enters this stage
+    output wire        halt_out
 );
     // Propagate the enable signal to the next stage.  For the special
     // halt instruction the pipeline is stalled by clearing the enable
     // line.
     // Halt instructions reside in the upper opcode byte
     assign enable_out = (instr_in[23:16] == `OPC_S_HLT) ? 1'b0 : enable_in;
+    assign halt_out   = enable_in && (instr_in[23:16] == `OPC_S_HLT);
 
     // Stage output prior to latching.  This is kept as a separate wire so
     // that future execute logic can easily be inserted here.


### PR DESCRIPTION
## Summary
- detect `HLT` opcode in the execute stage
- latch a `halted` flag
- stop PC updates and disable all pipeline stages when halted

## Testing
- `iverilog -g2012 -o test.vvp src/*.v`
- `vvp test.vvp`

------
https://chatgpt.com/codex/tasks/task_e_686993b1de7c832f9b4562399147933f